### PR TITLE
Feature/add pact tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+/.idea/
 
 # Used by dotenv library to load environment variables.
 # .env
@@ -48,3 +49,6 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+## pact generated log files
+/log/

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 gem 'nexboard-api', path: '.'
 
 group :development, :test do
@@ -5,6 +7,7 @@ group :development, :test do
   gem 'rspec'
   gem 'rake'
   gem 'webmock'
+  gem 'pact'
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,11 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do | task |
+  task.pattern = "spec/lib/*.rb"
+end
 task default: :spec
+
+RSpec::Core::RakeTask.new(:pact) do | task |
+  task.pattern = "spec/pacts/nexboard_api_pact_spec.rb"
+end

--- a/spec/pact_helper.rb
+++ b/spec/pact_helper.rb
@@ -4,7 +4,6 @@ require 'nexboard_api'
 
 Pact.service_consumer "OpenHPI" do
   has_pact_with "nexboard" do
-    puts "Starting mock nexboard server"
     mock_service :nexboard do
       port 1234
     end

--- a/spec/pact_helper.rb
+++ b/spec/pact_helper.rb
@@ -1,0 +1,12 @@
+require 'pact/consumer/rspec'
+require 'restify'
+require 'nexboard_api'
+
+Pact.service_consumer "OpenHPI" do
+  has_pact_with "nexboard" do
+    puts "Starting mock nexboard server"
+    mock_service :nexboard do
+      port 1234
+    end
+  end
+end

--- a/spec/pacts/nexboard_api_pact_spec.rb
+++ b/spec/pacts/nexboard_api_pact_spec.rb
@@ -5,6 +5,8 @@ describe NexboardApi, :pact => true do
   let(:user_id) { '1337' }
   let(:base_url) { 'http://localhost:1234/' }
   let(:params)  { {api_key: api_key, user_id: user_id, base_url: base_url} }
+  let(:encoded_credentials) { URI::encode('token=' + api_key + '&userId=' + user_id) }
+  let(:encoded_token) { URI::encode('token=' + api_key) }
   client = nil
 
   before do
@@ -16,9 +18,9 @@ describe NexboardApi, :pact => true do
     let(:response) { [{project_id: '1'}, {project_id: '2'}] }
 
     before do
-      nexboard.given("some projects exist").
-          upon_receiving("a request for all project ids").
-          with(method: :get, path: '/projects', query: URI::encode('token=' + api_key + '&userId=' + user_id)).
+      nexboard.given("user has valid credentials and some projects exist").
+          upon_receiving("a request to get all projects").
+          with(method: :get, path: '/projects', query: encoded_credentials).
           will_respond_with(
               status: 200,
               headers: {'Content-Type' => 'application/json'},
@@ -28,6 +30,31 @@ describe NexboardApi, :pact => true do
     it "returns the project ids" do
       project_ids = client.get_project_ids
       expect(project_ids).to eq(['1', '2'])
+    end
+
+  end
+
+  describe "create_project" do
+    let(:title) { 'A new project' }
+    let(:description) { 'This is a new project' }
+    let(:project_id) { '1' }
+    let(:response) { {project_id: project_id, title: title} }
+    let(:project_data) { {title: title, description: description} }
+    let(:post_body) { {title: title, description: description, user_id: user_id} }
+
+    before do
+      nexboard.given("user has valid credentials").
+          upon_receiving("a request to create a project").
+          with(method: :post, path: '/projects', query: encoded_token, body: post_body).
+          will_respond_with(
+              status: 200,
+              headers: {'Content-Type' => 'application/json'},
+              body: response)
+    end
+
+    it "returns a new project" do
+      project = client.create_project(project_data)
+      expect(project.project_id).to eq(project_id)
     end
 
   end

--- a/spec/pacts/nexboard_api_pact_spec.rb
+++ b/spec/pacts/nexboard_api_pact_spec.rb
@@ -1,0 +1,35 @@
+require 'pact_helper'
+
+describe NexboardApi, :pact => true do
+  let(:api_key) { 'RandomApiKey' }
+  let(:user_id) { '1337' }
+  let(:base_url) { 'http://localhost:1234/' }
+  let(:params)  { {api_key: api_key, user_id: user_id, base_url: base_url} }
+  client = nil
+
+  before do
+    # Configure your client to point to the stub service on localhost using the port you have specified
+    client = NexboardApi.new **params
+  end
+
+  describe "get_project_ids" do
+    let(:response) { [{project_id: '1'}, {project_id: '2'}] }
+
+    before do
+      nexboard.given("some projects exist").
+          upon_receiving("a request for all project ids").
+          with(method: :get, path: '/projects', query: URI::encode('token=' + api_key + '&userId=' + user_id)).
+          will_respond_with(
+              status: 200,
+              headers: {'Content-Type' => 'application/json'},
+              body: response)
+    end
+
+    it "returns the project ids" do
+      project_ids = client.get_project_ids
+      expect(project_ids).to eq(['1', '2'])
+    end
+
+  end
+
+end

--- a/spec/pacts/nexboard_api_pact_spec.rb
+++ b/spec/pacts/nexboard_api_pact_spec.rb
@@ -5,14 +5,10 @@ describe NexboardApi, :pact => true do
   let(:user_id) { '1337' }
   let(:base_url) { 'http://localhost:1234/' }
   let(:params)  { {api_key: api_key, user_id: user_id, base_url: base_url} }
-  let(:encoded_credentials) { URI::encode('token=' + api_key + '&userId=' + user_id) }
-  let(:encoded_token) { URI::encode('token=' + api_key) }
-  client = nil
+  let(:encoded_credentials) { URI::encode("token=#{api_key}&userId=#{user_id}") }
+  let(:encoded_token) { URI::encode("token=#{api_key}") }
+  let(:client) { NexboardApi.new **params }
 
-  before do
-    # Configure your client to point to the stub service on localhost using the port you have specified
-    client = NexboardApi.new **params
-  end
 
   describe "get_project_ids" do
     let(:response) { [{project_id: '1'}, {project_id: '2'}] }
@@ -55,6 +51,55 @@ describe NexboardApi, :pact => true do
     it "returns a new project" do
       project = client.create_project(project_data)
       expect(project.project_id).to eq(project_id)
+    end
+
+  end
+
+  describe "get_boards_for_project" do
+    let(:title) { 'A board' }
+    let(:project_id) { '1' }
+    let(:board_id) { '101' }
+    let(:response) { [{boardId: board_id, title: title}] }
+
+    before do
+      nexboard.given("user has valid credentials and an existing project with boards").
+          upon_receiving("a request to get boards of a project").
+          with(method: :get, path: "/projects/#{project_id}/boards", query: encoded_credentials).
+          will_respond_with(
+              status: 200,
+              headers: {'Content-Type' => 'application/json'},
+              body: response)
+    end
+
+    it "returns a new project" do
+      boards = client.get_boards_for_project( {project_id: project_id} )
+      expect(boards.first.boardId).to eq(board_id)
+    end
+
+  end
+
+  describe "create_board_for_project" do
+    let(:title) { 'A new project' }
+    let(:description) { 'This is a new project' }
+    let(:project_id) { '1' }
+    let(:board_id) { '101' }
+    let(:response) { {board_id: board_id, project_id: project_id, title: title} }
+    let(:board_data) { {title: title, description: description, project_id: project_id} }
+    let(:post_body) { {title: title, description: description, project_id: project_id, user_id: user_id} }
+
+    before do
+      nexboard.given("user has valid credentials and an existing project").
+          upon_receiving("a request to create a project").
+          with(method: :post, path: '/boards', query: encoded_token, body: post_body).
+          will_respond_with(
+              status: 200,
+              headers: {'Content-Type' => 'application/json'},
+              body: response)
+    end
+
+    it "returns a new project" do
+      board = client.create_board_for_project(board_data)
+      expect(board.board_id).to eq(board_id)
     end
 
   end

--- a/spec/pacts/openhpi-nexboard.json
+++ b/spec/pacts/openhpi-nexboard.json
@@ -52,6 +52,53 @@
           "title": "A new project"
         }
       }
+    },
+    {
+      "description": "a request to get boards of a project",
+      "providerState": "user has valid credentials and an existing project with boards",
+      "request": {
+        "method": "get",
+        "path": "/projects/1/boards",
+        "query": "token=RandomApiKey&userId=1337"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": [
+          {
+            "boardId": "101",
+            "title": "A board"
+          }
+        ]
+      }
+    },
+    {
+      "description": "a request to create a project",
+      "providerState": "user has valid credentials and an existing project",
+      "request": {
+        "method": "post",
+        "path": "/boards",
+        "query": "token=RandomApiKey",
+        "body": {
+          "title": "A new project",
+          "description": "This is a new project",
+          "project_id": "1",
+          "user_id": "1337"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "board_id": "101",
+          "project_id": "1",
+          "title": "A new project"
+        }
+      }
     }
   ],
   "metadata": {

--- a/spec/pacts/openhpi-nexboard.json
+++ b/spec/pacts/openhpi-nexboard.json
@@ -7,8 +7,8 @@
   },
   "interactions": [
     {
-      "description": "a request for all project ids",
-      "providerState": "some projects exist",
+      "description": "a request to get all projects",
+      "providerState": "user has valid credentials and some projects exist",
       "request": {
         "method": "get",
         "path": "/projects",
@@ -27,6 +27,30 @@
             "project_id": "2"
           }
         ]
+      }
+    },
+    {
+      "description": "a request to create a project",
+      "providerState": "user has valid credentials",
+      "request": {
+        "method": "post",
+        "path": "/projects",
+        "query": "token=RandomApiKey",
+        "body": {
+          "title": "A new project",
+          "description": "This is a new project",
+          "user_id": "1337"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "project_id": "1",
+          "title": "A new project"
+        }
       }
     }
   ],

--- a/spec/pacts/openhpi-nexboard.json
+++ b/spec/pacts/openhpi-nexboard.json
@@ -1,0 +1,38 @@
+{
+  "consumer": {
+    "name": "OpenHPI"
+  },
+  "provider": {
+    "name": "nexboard"
+  },
+  "interactions": [
+    {
+      "description": "a request for all project ids",
+      "providerState": "some projects exist",
+      "request": {
+        "method": "get",
+        "path": "/projects",
+        "query": "token=RandomApiKey&userId=1337"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": [
+          {
+            "project_id": "1"
+          },
+          {
+            "project_id": "2"
+          }
+        ]
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    }
+  }
+}


### PR DESCRIPTION
We would like to add pact contract tests to this module so that we can ensure that changes in our neXboard API are compatible with this dependency.
The generated contracts will be used in the neXboard development cycle to ensure we do not break this module when we update our API.

Contributions:
* add pact dependency
* add rake task for generating pact
* add pact tests