### PR TITLE
improve pacts

### DIFF
--- a/lib/nexboard_api.rb
+++ b/lib/nexboard_api.rb
@@ -31,6 +31,7 @@ class NexboardApi
 
     Restify.new(@base_url + 'projects')
         .post(data, token: @api_key)
+        .headers({'Content-Type' => 'application/json'})
         .value!
   end
 

--- a/lib/nexboard_api.rb
+++ b/lib/nexboard_api.rb
@@ -19,7 +19,7 @@ class NexboardApi
                    .get(userId: @user_id, token: @api_key)
                    .value!
 
-    projects.data.map{|project| project['project_id']}
+    projects.data.map{|project| project['id']}
   end
 
   def create_project(title:, description:)
@@ -31,7 +31,6 @@ class NexboardApi
 
     Restify.new(@base_url + 'projects')
         .post(data, token: @api_key)
-        .headers({'Content-Type' => 'application/json'})
         .value!
   end
 

--- a/spec/pacts/nexboard_api_pact_spec.rb
+++ b/spec/pacts/nexboard_api_pact_spec.rb
@@ -3,8 +3,8 @@ require 'pact_helper'
 describe NexboardApi, :pact => true do
   let(:api_key) { 'OpenHPIAPIKey' }
   let(:user_id) { '__user_id__' }
-  let(:project1_id) { '__project_1_id__' }
-  let(:project2_id) { '__project_2_id__' }
+  let(:project1_id) { 10001 }
+  let(:project2_id) { 10002 }
   let(:base_url) { 'http://localhost:1234/' }
   let(:params)  { {api_key: api_key, user_id: user_id, base_url: base_url} }
   let(:encoded_credentials) { URI::encode("token=#{api_key}&userId=#{user_id}") }
@@ -13,7 +13,7 @@ describe NexboardApi, :pact => true do
 
 
   describe "get_project_ids" do
-    let(:response) { [{title: 'Project1'}, {title: 'Project2'}] }
+    let(:response) { [{id: project1_id, title: 'Project1'}, {id: project2_id, title: 'Project2'}] }
 
     before do
       nexboard.given("user has valid credentials and some projects exist").

--- a/spec/pacts/nexboard_api_pact_spec.rb
+++ b/spec/pacts/nexboard_api_pact_spec.rb
@@ -1,8 +1,10 @@
 require 'pact_helper'
 
 describe NexboardApi, :pact => true do
-  let(:api_key) { 'RandomApiKey' }
-  let(:user_id) { '1337' }
+  let(:api_key) { 'OpenHPIAPIKey' }
+  let(:user_id) { '__user_id__' }
+  let(:project1_id) { '__project_1_id__' }
+  let(:project2_id) { '__project_2_id__' }
   let(:base_url) { 'http://localhost:1234/' }
   let(:params)  { {api_key: api_key, user_id: user_id, base_url: base_url} }
   let(:encoded_credentials) { URI::encode("token=#{api_key}&userId=#{user_id}") }
@@ -11,7 +13,7 @@ describe NexboardApi, :pact => true do
 
 
   describe "get_project_ids" do
-    let(:response) { [{project_id: '1'}, {project_id: '2'}] }
+    let(:response) { [{title: 'Project1'}, {title: 'Project2'}] }
 
     before do
       nexboard.given("user has valid credentials and some projects exist").
@@ -19,13 +21,13 @@ describe NexboardApi, :pact => true do
           with(method: :get, path: '/projects', query: encoded_credentials).
           will_respond_with(
               status: 200,
-              headers: {'Content-Type' => 'application/json'},
+              headers: {'Content-Type' => 'application/json; charset=utf-8'},
               body: response)
     end
 
     it "returns the project ids" do
       project_ids = client.get_project_ids
-      expect(project_ids).to eq(['1', '2'])
+      expect(project_ids).to eq([project1_id, project2_id])
     end
 
   end
@@ -33,8 +35,7 @@ describe NexboardApi, :pact => true do
   describe "create_project" do
     let(:title) { 'A new project' }
     let(:description) { 'This is a new project' }
-    let(:project_id) { '1' }
-    let(:response) { {project_id: project_id, title: title} }
+    let(:response) { {description: description, title: title} }
     let(:project_data) { {title: title, description: description} }
     let(:post_body) { {title: title, description: description, user_id: user_id} }
 
@@ -44,62 +45,59 @@ describe NexboardApi, :pact => true do
           with(method: :post, path: '/projects', query: encoded_token, body: post_body).
           will_respond_with(
               status: 200,
-              headers: {'Content-Type' => 'application/json'},
+              headers: {'Content-Type' => 'application/json; charset=utf-8'},
               body: response)
     end
 
     it "returns a new project" do
       project = client.create_project(project_data)
-      expect(project.project_id).to eq(project_id)
+      expect(project.title).to eq(title)
     end
 
   end
 
   describe "get_boards_for_project" do
     let(:title) { 'A board' }
-    let(:project_id) { '1' }
-    let(:board_id) { '101' }
-    let(:response) { [{boardId: board_id, title: title}] }
+    let(:description) { 'This is a great Board'}
+    let(:response) { [{description: description, title: title}] }
 
     before do
       nexboard.given("user has valid credentials and an existing project with boards").
           upon_receiving("a request to get boards of a project").
-          with(method: :get, path: "/projects/#{project_id}/boards", query: encoded_credentials).
+          with(method: :get, path: "/projects/#{project1_id}/boards", query: encoded_credentials).
           will_respond_with(
               status: 200,
-              headers: {'Content-Type' => 'application/json'},
+              headers: {'Content-Type' => 'application/json; charset=utf-8'},
               body: response)
     end
 
     it "returns a new project" do
-      boards = client.get_boards_for_project( {project_id: project_id} )
-      expect(boards.first.boardId).to eq(board_id)
+      boards = client.get_boards_for_project( {project_id: project1_id} )
+      expect(boards.first.title).to eq(title)
     end
 
   end
 
   describe "create_board_for_project" do
-    let(:title) { 'A new project' }
-    let(:description) { 'This is a new project' }
-    let(:project_id) { '1' }
-    let(:board_id) { '101' }
-    let(:response) { {board_id: board_id, project_id: project_id, title: title} }
-    let(:board_data) { {title: title, description: description, project_id: project_id} }
-    let(:post_body) { {title: title, description: description, project_id: project_id, user_id: user_id} }
+    let(:title) { 'New Board' }
+    let(:description) { 'This is a new Board' }
+    let(:response) { {description: description, title: title} }
+    let(:board_data) { {title: title, description: description, project_id: project1_id} }
+    let(:post_body) { {title: title, description: description, project_id: project1_id, user_id: user_id} }
 
     before do
       nexboard.given("user has valid credentials and an existing project").
-          upon_receiving("a request to create a project").
+          upon_receiving("a request to create a board").
           with(method: :post, path: '/boards', query: encoded_token, body: post_body).
           will_respond_with(
               status: 200,
-              headers: {'Content-Type' => 'application/json'},
+              headers: {'Content-Type' => 'application/json; charset=utf-8'},
               body: response)
     end
 
-    it "returns a new project" do
+    it "returns a new Board" do
       board = client.create_board_for_project(board_data)
-      expect(board.board_id).to eq(board_id)
+      expect(board.title).to eq(title)
     end
 
   end

--- a/spec/pacts/openhpi-nexboard.json
+++ b/spec/pacts/openhpi-nexboard.json
@@ -21,9 +21,11 @@
         },
         "body": [
           {
+            "id": 10001,
             "title": "Project1"
           },
           {
+            "id": 10002,
             "title": "Project2"
           }
         ]
@@ -35,6 +37,9 @@
       "request": {
         "method": "post",
         "path": "/projects",
+        "headers": {
+          "Content-Type": "application/json"
+        },
         "query": "token=OpenHPIAPIKey",
         "body": {
           "title": "A new project",
@@ -58,7 +63,7 @@
       "providerState": "user has valid credentials and an existing project with boards",
       "request": {
         "method": "get",
-        "path": "/projects/__project_1_id__/boards",
+        "path": "/projects/10001/boards",
         "query": "token=OpenHPIAPIKey&userId=__user_id__"
       },
       "response": {
@@ -80,11 +85,14 @@
       "request": {
         "method": "post",
         "path": "/boards",
+        "headers": {
+          "Content-Type": "application/json"
+        },
         "query": "token=OpenHPIAPIKey",
         "body": {
           "title": "New Board",
           "description": "This is a new Board",
-          "project_id": "__project_1_id__",
+          "project_id": 10001,
           "user_id": "__user_id__"
         }
       },

--- a/spec/pacts/openhpi-nexboard.json
+++ b/spec/pacts/openhpi-nexboard.json
@@ -12,19 +12,19 @@
       "request": {
         "method": "get",
         "path": "/projects",
-        "query": "token=RandomApiKey&userId=1337"
+        "query": "token=OpenHPIAPIKey&userId=__user_id__"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json; charset=utf-8"
         },
         "body": [
           {
-            "project_id": "1"
+            "title": "Project1"
           },
           {
-            "project_id": "2"
+            "title": "Project2"
           }
         ]
       }
@@ -35,20 +35,20 @@
       "request": {
         "method": "post",
         "path": "/projects",
-        "query": "token=RandomApiKey",
+        "query": "token=OpenHPIAPIKey",
         "body": {
           "title": "A new project",
           "description": "This is a new project",
-          "user_id": "1337"
+          "user_id": "__user_id__"
         }
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json; charset=utf-8"
         },
         "body": {
-          "project_id": "1",
+          "description": "This is a new project",
           "title": "A new project"
         }
       }
@@ -58,45 +58,44 @@
       "providerState": "user has valid credentials and an existing project with boards",
       "request": {
         "method": "get",
-        "path": "/projects/1/boards",
-        "query": "token=RandomApiKey&userId=1337"
+        "path": "/projects/__project_1_id__/boards",
+        "query": "token=OpenHPIAPIKey&userId=__user_id__"
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json; charset=utf-8"
         },
         "body": [
           {
-            "boardId": "101",
+            "description": "This is a great Board",
             "title": "A board"
           }
         ]
       }
     },
     {
-      "description": "a request to create a project",
+      "description": "a request to create a board",
       "providerState": "user has valid credentials and an existing project",
       "request": {
         "method": "post",
         "path": "/boards",
-        "query": "token=RandomApiKey",
+        "query": "token=OpenHPIAPIKey",
         "body": {
-          "title": "A new project",
-          "description": "This is a new project",
-          "project_id": "1",
-          "user_id": "1337"
+          "title": "New Board",
+          "description": "This is a new Board",
+          "project_id": "__project_1_id__",
+          "user_id": "__user_id__"
         }
       },
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/json"
+          "Content-Type": "application/json; charset=utf-8"
         },
         "body": {
-          "board_id": "101",
-          "project_id": "1",
-          "title": "A new project"
+          "description": "This is a new Board",
+          "title": "New Board"
         }
       }
     }


### PR DESCRIPTION
In order to get the pact tests to pass in our pipeline, we had to make some slight adjustments. ID's are often autogenerated in our code, so we had to change how they are used in these tests. Moreover, our test server is very strict regarding header validation, so we had to adjust those as well.

Contributions
* use placeholder for userId
* add content type headers
* fix typos
* fix project id extraction (project_id --> id)